### PR TITLE
Add C4TK Chicago to events

### DIFF
--- a/newsletter.md
+++ b/newsletter.md
@@ -18,6 +18,7 @@ There's a new Meetup group in Lafayette focused on [Google development](https://
 ## Upcoming nearby events:
 * 06/23 -- IndyPy [Pythonology Lecture Series: Python Web Frameworks](https://www.eventbrite.com/e/pythology-lecture-series-web-framework-shootout-tickets-32697463995)
 * 06/26 -- Indy DevOps [meeting](https://www.meetup.com/IndyDevOps/events/qlswtjywjbjc/)
+* 07/28-30 -- Chicago [Code for the Kingdom Hackathon](https://www.chic4tk.tech/)
 * 09/12-13 -- [DevOps Days Chicago](https://www.devopsdays.org/events/2017-chicago/)
 
 ## Open CfPs:


### PR DESCRIPTION
Hello!  I'm helping to organize a hackathon for social good in Chicago in July.  I would love to get this added to the listing of events here.  I've really been wanting to get involved in HackLafayette (I live in Lafayette), although my travel schedule this spring prevented it.  Hopefully soon.

Basically the event in July is a gathering of mostly Christian devs, designers, and entrepreneurs that will work on projects that have a positive impact in the Chicago community.  Participants don't need to be Christians to join.  Anyone is welcome, and I hope some participants from Lafayette will make the trek! 